### PR TITLE
Directly return 0 when the input string is '0'

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
 module.exports = function millisecond(ms) {
   'use strict';
 
-  if ('string' !== typeof ms || +ms) return +ms;
+  if ('string' !== typeof ms || '0' === ms || +ms) return +ms;
 
   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(ms)
     , second = 1000


### PR DESCRIPTION
This fixes an edge case that occurs when the input string is `'0'`.
